### PR TITLE
add hide only from main menu

### DIFF
--- a/Packages/Sites/CodeQ.Site/Configuration/NodeTypes.Document.Page.yaml
+++ b/Packages/Sites/CodeQ.Site/Configuration/NodeTypes.Document.Page.yaml
@@ -9,3 +9,10 @@
   constraints:
     nodeTypes:
       'CodeQ.Site:HomePage': FALSE
+  properties:
+    hideFromMainMenu:
+      type: boolean
+      ui:
+        label: 'Im Hauptmenü verbergen'
+        inspector:
+          group: visibility

--- a/Packages/Sites/CodeQ.Site/Resources/Private/Fusion/Components/Navigation/Navigation.fusion
+++ b/Packages/Sites/CodeQ.Site/Resources/Private/Fusion/Components/Navigation/Navigation.fusion
@@ -20,7 +20,7 @@ prototype(CodeQ.Site:Components.Navigation.LevelRenderer) < prototype(Neos.Fusio
 	title = CodeQ.Site:Components.Navigation.Item
 	nextLevel = Neos.Fusion:Collection {
 		@if.notEmpty = ${this.collection.count() > 0}
-		collection = ${q(node).children('[instanceof Neos.Neos:Document][_hiddenInIndex != TRUE]')}
+		collection = ${q(node).children('[instanceof Neos.Neos:Document][_hiddenInIndex != TRUE][hideFromMainMenu != TRUE]')}
 		itemName = 'node'
 		itemRenderer = CodeQ.Site:Components.Navigation.LevelRenderer
 	}


### PR DESCRIPTION
Adds the option to hide a page only from the main menu (and not also from other navigation menus, such as the footer navigation)