### PR TITLE
BUGFIX: Fix .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,12 +16,12 @@ indent_size = 4
 quote_type = single
 
 # 2-space files
-[{*.{yaml,yml,sh,jscsrc},package.json,.*rc}]
+[{*.yaml,*.yml,*.sh,*.jscsrc,package.json,.*rc}]
 indent_style = space
 indent_size = 2
 
 # PHP should follow the PSR-2 standard
-[*.{json,php}]
+[{*.json,*.php}]
 indent_style = space
 indent_size = 4
 
@@ -42,7 +42,7 @@ max_line_length = 1000
 indent_size = 1
 max_line_length = 1000
 
-[*.{note,md,edit,read}]
+[{*.note,*.md,*.edit,*.read}]
 indent_size = 2
 trim_trailing_whitespace = false
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -12,34 +12,32 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = space
-indent_size = 4
+indent_size = 2
 quote_type = single
 
-# 2-space files
-[{*.yaml,*.yml,*.sh,*.jscsrc,.*rc}]
-indent_size = 2
+# PHP should follow the PSR-2 standard
+[*.php]
+indent_size = 4
+
+# JS, SASS, HTML should use tabs, to reduce conflicts
+[*.{js,scss,html}]
+indent_style = tab
+
+# Markdown et al. use trailing whitespace for line breaks
+[*.{note,md,edit,read}]
+trim_trailing_whitespace = false
 
 # JSON can have longer lines
 [*.json]
 max_line_length = 1000
 
-[package.json]
-indent_size = 2
-
-# JS should use tabs, to reduce conflicts
-[*.js]
-indent_style = tab
+# Composer uses 4 spaces itself
+[composer.json]
+indent_size = 4
 
 [Sites.xml]
 indent_size = 1
 max_line_length = 1000
 
-[{*.note,*.md,*.edit,*.read}]
-indent_size = 2
-trim_trailing_whitespace = false
-
 [Makefile]
 indent_style = tab
-
-[*.css.d.ts]
-indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -35,7 +35,7 @@ indent_size = 4
 indent_style = tab
 
 # JSON can have longer lines
-[*.{json}]
+[*.json]
 max_line_length = 1000
 
 [Sites.xml]

--- a/.editorconfig
+++ b/.editorconfig
@@ -16,7 +16,7 @@ indent_size = 4
 quote_type = single
 
 # 2-space files
-[{*.yaml,*.yml,*.sh,*.jscsrc,package.json,.*rc}]
+[{*.yaml,*.yml,*.sh,*.jscsrc,.*rc}]
 indent_style = space
 indent_size = 2
 
@@ -24,6 +24,14 @@ indent_size = 2
 [{*.json,*.php}]
 indent_style = space
 indent_size = 4
+
+# JSON can have longer lines
+[*.json]
+max_line_length = 1000
+
+[package.json]
+indent_style = space
+indent_size = 2
 
 # Fusion uses 4 spaces
 [*.fusion]
@@ -33,10 +41,6 @@ indent_size = 4
 # JS should use tabs, to reduce conflicts
 [*.js]
 indent_style = tab
-
-# JSON can have longer lines
-[*.json]
-max_line_length = 1000
 
 [Sites.xml]
 indent_size = 1

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,7 +10,7 @@ root = true
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true
-trim_trailing-whitespace = true
+trim_trailing_whitespace = true
 indent_style = space
 indent_size = 4
 quote_type = single
@@ -44,7 +44,7 @@ max_line_length = 1000
 
 [*.{note,md,edit,read}]
 indent_size = 2
-trim_trailing-whitespace = false
+trim_trailing_whitespace = false
 
 [Makefile]
 indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -17,26 +17,14 @@ quote_type = single
 
 # 2-space files
 [{*.yaml,*.yml,*.sh,*.jscsrc,.*rc}]
-indent_style = space
 indent_size = 2
-
-# PHP should follow the PSR-2 standard
-[{*.json,*.php}]
-indent_style = space
-indent_size = 4
 
 # JSON can have longer lines
 [*.json]
 max_line_length = 1000
 
 [package.json]
-indent_style = space
 indent_size = 2
-
-# Fusion uses 4 spaces
-[*.fusion]
-indent_style = space
-indent_size = 4
 
 # JS should use tabs, to reduce conflicts
 [*.js]


### PR DESCRIPTION
While using your skeleton for my first Neos project, i (and PHPStorm) became aware of some inconsistencies in the .editorconfig. Some fixes are required, and some are nice to have. In the last commit i adapted it to the .editorconfig of the [Neos Development Collection](https://github.com/neos/neos-development-collection) which uses a 2 spaces indentation by default instead of a 4 spaces. This reduces the set of rules, but maybe you still want to revert that last commit.