### PR TITLE
Fixed a typo in .editorconfig.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,7 +10,7 @@ root = true
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true
-trim_trailing-whitespace = true
+trim_trailing_whitespace = true
 indent_style = space
 indent_size = 4
 quote_type = single
@@ -44,7 +44,7 @@ max_line_length = 1000
 
 [*.{note,md,edit,read}]
 indent_size = 2
-trim_trailing-whitespace = false
+trim_trailing_whitespace = false
 
 [Makefile]
 indent_style = tab


### PR DESCRIPTION
It seems there was a typo regarding `trim_trailing-whitespace` (at least according to editorconfig.org).