### PR TITLE
BUGFIX: Prevent newly created documents from vanishing in the document tree by only applying inline editable wrapping on the footer on the home page

### DIFF
--- a/DistributionPackages/CodeQ.Site/Resources/Private/Fusion/Component/Footer/Footer.fusion
+++ b/DistributionPackages/CodeQ.Site/Resources/Private/Fusion/Component/Footer/Footer.fusion
@@ -1,5 +1,4 @@
-prototype(CodeQ.Site:Component.Footer) < prototype(Neos.Neos:ContentComponent) {
-    @context.node = ${site}
+prototype(CodeQ.Site:Component.Footer) < prototype(Neos.Fusion:Component) {
     year = ${Date.format(Date.now(), 'Y')}
     footerInfo = Neos.Neos:Editable {
         node = ${site}
@@ -29,5 +28,13 @@ prototype(CodeQ.Site:Component.Footer) < prototype(Neos.Neos:ContentComponent) {
         entryTags {
             1 = ${Neos.Caching.nodeTag(site)}
         }
+    }
+
+    // The footer should only be inline editable on the home page,
+    // otherwise the Neos UI will show a weird behavior
+    @process.contentElementWrapping = Neos.Neos:ContentElementWrapping {
+        @if.isOnSiteNode = ${site == documentNode}
+        node = ${site}
+        @position = 'end'
     }
 }


### PR DESCRIPTION
As mentioned in #27, newly created documents would vanish in the document tree and would only become visible after a _hard reload_. The issue is rooted in the fact, that the footer is inline editable, however the context node is the site node.

To prevent this behavior, the footer is now only inline editable on the home page, where `site == documentNode`.